### PR TITLE
Update frontend developer agent to use Gemini 3.0

### DIFF
--- a/src/agents/frontend_developer_agent.py
+++ b/src/agents/frontend_developer_agent.py
@@ -3,6 +3,7 @@
 from typing import Any, Callable, Dict, Optional
 
 from .base_agent import AgentConfig, AgentMode, AgentResult, BaseAgent
+from ..llm import LLMProvider
 from ..tools.tool_registry import ToolRegistry
 
 
@@ -85,6 +86,8 @@ class FrontendDeveloperAgent(BaseAgent):
                 "create_prototype",
             ],
             mode=mode,
+            llm_provider=LLMProvider.GEMINI,
+            model="gemini-3.0-flash",
         )
         super().__init__(config, tool_registry, approval_callback)
 


### PR DESCRIPTION
Configure the FrontendDeveloperAgent to use Google's Gemini 3.0 Flash
model instead of the default environment-based provider configuration.