### PR TITLE
feat: give agents MCP server access via CLI tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,3 +95,19 @@ JIRA_API_TOKEN=your-jira-api-token
 CONFLUENCE_BASE_URL=https://your-domain.atlassian.net
 CONFLUENCE_USERNAME=your-email@example.com
 CONFLUENCE_API_TOKEN=your-confluence-api-token
+
+# =============================================================================
+# MCP (Model Context Protocol) CLI Integration (Optional)
+# =============================================================================
+# Lets agents reach MCP servers (Atlassian, GitHub, filesystem, ...) via the
+# CLI tools (mcp_list_servers / mcp_list_tools / mcp_call_tool / mcp_run_command).
+# Servers are declared in .github/copilot/mcp-config.json.
+#
+# Path to the MCP server config (default: .github/copilot/mcp-config.json)
+MCP_CONFIG_PATH=.github/copilot/mcp-config.json
+# Command-line MCP client used to execute command prompts (default: "mcp call")
+MCP_CLIENT=mcp call
+# Set to 1/true to actually execute MCP commands; otherwise calls are dry-run
+MCP_EXECUTE=0
+# Token used by the GitHub MCP server (referenced from mcp-config.json env)
+# GITHUB_TOKEN=your-github-token

--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -64,10 +64,19 @@ handoffs:                 # optional — ordered hand-off targets
 ---
 ```
 
+## MCP servers
+
+Every agent can reach configured **MCP servers** (Atlassian, GitHub, filesystem)
+through the MCP CLI tools — `mcp_list_servers`, `mcp_list_tools`, `mcp_call_tool`,
+`mcp_run_command` — which execute command prompts against the servers declared in
+[`../copilot/mcp-config.json`](../copilot/mcp-config.json). See
+[`../instructions/mcp.instructions.md`](../instructions/mcp.instructions.md) and
+the [`mcp-sync`](../prompts/mcp-sync.prompt.md) task.
+
 ## Related
 
 - `../../AGENTS.md` — repo-wide project instructions
-- `../instructions/` — scoped guidance (tools catalogue, integrations, conventions)
+- `../instructions/` — scoped guidance (tools catalogue, integrations, MCP, conventions)
 - `../prompts/` — reusable task prompts
 - `../../README.md` — full project overview
 - `../../GETTING_STARTED.md` — walkthrough

--- a/.github/agents/business-study.agent.md
+++ b/.github/agents/business-study.agent.md
@@ -46,12 +46,17 @@ generated/<project>/docs/RISK_LOG.md
 The project folder is expected to exist already (created by Feasibility). If not, create it.
 
 ## Jira / Confluence sync
-When the Atlassian MCP server is available:
+Prefer the named Python tools:
 - `jira_create_user_story` per requirement (with MoSCoW label)
 - `jira_bulk_create_requirements` to batch
 - `jira_transition_issue` for status changes
 - `sync_work_item_status` → keeps Confluence in sync
 - `confluence_create_dsdm_doc` to publish the business study
+
+When Atlassian is reachable only as an **MCP server**, use the MCP CLI tools
+(`mcp_list_servers` → `mcp_list_tools(server="atlassian")` →
+`mcp_call_tool(server="atlassian", tool="jira_bulk_create_requirements", arguments={...})`).
+See `../instructions/mcp.instructions.md`. Skip silently if no server is configured.
 
 ## Stop conditions
 Once the three docs are on disk and (optionally) synced, write a one-paragraph summary listing the count of Must/Should/Could/Won't items and the next-phase inputs, then stop.

--- a/.github/agents/dev-lead.agent.md
+++ b/.github/agents/dev-lead.agent.md
@@ -61,6 +61,14 @@ generated/<project>/docs/architecture/decisions/001-database-choice.md
 generated/<project>/docs/architecture/decisions/002-api-style.md
 ```
 
+## MCP CLI integration (optional)
+Publish the TRD / ADRs and coordinate work through **MCP servers** when
+available (see `../instructions/mcp.instructions.md`):
+- `mcp_call_tool(server="atlassian", tool="confluence_create_dsdm_doc", arguments={...})` to publish the TRD.
+- `mcp_call_tool(server="github", tool="create_issue", arguments={...})` to raise implementation tasks for the specialist agents.
+Discover names with `mcp_list_tools` first; calls are dry-run unless `MCP_EXECUTE=1`
+and require approval. Skip silently if no server is configured.
+
 ## Hand-offs
 For deep work in a specific layer, delegate to the specialised agents listed under `handoffs`. Provide them with the relevant TRD section + ADR(s) as context.
 

--- a/.github/agents/devops.agent.md
+++ b/.github/agents/devops.agent.md
@@ -67,6 +67,14 @@ generated/<project>/docs/MONITORING.md
 generated/<project>/docs/SECURITY.md
 ```
 
+## MCP CLI integration (optional)
+Where CI/CD, issue tracking, or docs live behind an **MCP server**, drive them
+via the MCP CLI tools (see `../instructions/mcp.instructions.md`):
+- `mcp_list_tools(server="github")` then `mcp_call_tool(server="github", tool="list_workflow_runs"|"create_issue", arguments={...})` to inspect pipelines or file findings.
+- `mcp_call_tool(server="atlassian", tool="jira_add_comment", arguments={...})` to post scan / quality-gate results.
+These execute command prompts through the client CLI; they are dry-run unless
+`MCP_EXECUTE=1` and require approval. Cite the principle that motivates each call.
+
 ## Working style
 Whenever you act, **cite the principle** that motivates the action (e.g. "applying #2 — adding pytest-cov to the CI step").
 

--- a/.github/agents/feasibility.agent.md
+++ b/.github/agents/feasibility.agent.md
@@ -41,10 +41,17 @@ generated/<project>/docs/FEASIBILITY_REPORT.md
 If the project folder does not exist, create the skeleton first (`generated/<project>/docs/`, `generated/<project>/src/`, `generated/<project>/tests/`).
 
 ## Jira / Confluence sync (optional)
-When the Atlassian MCP server is configured:
+Prefer the named Python tools when available:
 - `jira_create_issue` for the feasibility epic
 - `jira_transition_issue` to mark "In Review" / "Done"
 - `confluence_create_dsdm_doc` to publish the report
+
+If the Atlassian integration is only reachable as an **MCP server**, reach it via
+the MCP CLI tools (see `../instructions/mcp.instructions.md`):
+- `mcp_list_servers` → confirm `atlassian` is configured (skip silently if not)
+- `mcp_list_tools(server="atlassian")` → discover exact tool names
+- `mcp_call_tool(server="atlassian", tool="jira_create_issue", arguments={...})`
+  to execute the command prompt (dry-run unless `MCP_EXECUTE=1`; pause for approval)
 
 ## Stop conditions
 After writing the report and (optionally) syncing to Jira/Confluence, output a one-paragraph summary including the recommendation and stop. Do not iterate further.

--- a/.github/agents/implementation.agent.md
+++ b/.github/agents/implementation.agent.md
@@ -57,5 +57,13 @@ generated/<project>/docs/LESSONS_LEARNED.md
 - `confluence_update_page` with actual outcomes
 - `confluence_create_dsdm_doc` for handover and training docs
 
+When those systems are reachable only as **MCP servers**, run the same
+operations via the MCP CLI tools, e.g.
+`mcp_call_tool(server="atlassian", tool="jira_transition_issue", arguments={"issue_key": ..., "target_status": "Deployed"})`.
+Because these are release actions, they inherit this agent's approval rules —
+inspect the dry-run `rendered_command` and get approval before executing
+(`MCP_EXECUTE=1`). See `../instructions/mcp.instructions.md`. You can also open a
+release/GitHub issue via `mcp_call_tool(server="github", tool="create_issue", ...)`.
+
 ## Stop conditions
 Once the system is deployed (or explicitly skipped), smoke tests pass, and handover docs are written, summarise outcomes, link the docs, and stop.

--- a/.github/agents/product-manager.agent.md
+++ b/.github/agents/product-manager.agent.md
@@ -50,5 +50,13 @@ If the project folder doesn't exist yet, create the standard skeleton (`generate
 - Mark every feature **Must / Should / Could / Won't** with rationale.
 - The PRD must be detailed enough that the **dev-lead** agent can derive a TRD from it without re-asking the user.
 
+## Jira / Confluence sync (optional)
+Publish the PRD and seed the backlog with the named Python tools, or — when
+Atlassian is reachable only as an **MCP server** — via the MCP CLI tools
+(`mcp_call_tool(server="atlassian", tool="confluence_create_dsdm_doc", arguments={...})`
+to publish the PRD; `mcp_call_tool(server="atlassian", tool="jira_create_user_story", ...)`
+per Must/Should feature). Discover names first with `mcp_list_tools`. Skip
+silently if no server is configured. See `../instructions/mcp.instructions.md`.
+
 ## Stop conditions
 After the PRD is on disk, write a one-paragraph summary listing feature counts per MoSCoW bucket and the path to the PRD, then stop.

--- a/.github/copilot/mcp-config.json
+++ b/.github/copilot/mcp-config.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "atlassian": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.atlassian.com/v1/sse"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "${workspaceFolder}/generated"]
+    }
+  }
+}

--- a/.github/instructions/dsdm-tools.instructions.md
+++ b/.github/instructions/dsdm-tools.instructions.md
@@ -138,6 +138,19 @@ All paths are placed under `generated/` automatically.
 ### Sync helpers (`src/tools/dsdm_tools.py`)
 - `sync_work_item_status`, `setup_jira_confluence_sync`, `get_sync_status`
 
+## MCP CLI tools (`src/tools/integrations/mcp_tools.py`)
+
+Reach any configured MCP server (Atlassian, GitHub, filesystem, …) by executing
+command prompts through a CLI client. See `mcp.instructions.md` for the full
+guide.
+
+| Tool | Purpose |
+|------|---------|
+| `mcp_list_servers` | List configured MCP servers (read-only) |
+| `mcp_list_tools` | Discover a server's tools via `tools/list` (read-only) |
+| `mcp_call_tool` | Call a server tool (`tools/call`) with JSON arguments (requires approval; dry-run unless `MCP_EXECUTE`) |
+| `mcp_run_command` | Run a raw MCP method — escape hatch (requires approval) |
+
 ## Tool registration
 
 Every tool above is wired in `src/tools/tool_registry.py` via `register_tool(...)`. To add a new tool, register it there and reference its name in the relevant agent's prompt body.

--- a/.github/instructions/integrations.instructions.md
+++ b/.github/instructions/integrations.instructions.md
@@ -33,6 +33,18 @@ Use `confluence_create_dsdm_doc(phase=..., title=..., content=...)` for canonica
 - Technical Requirements Document (TRD)
 - Implementation / Handover
 
+## MCP servers (CLI)
+
+Beyond the first-party Python integrations above, agents can reach **any
+configured MCP server** — Atlassian, GitHub, filesystem, … — by executing
+command prompts through the MCP CLI tools (`mcp_list_servers`, `mcp_list_tools`,
+`mcp_call_tool`, `mcp_run_command`). Servers are declared in
+`.github/copilot/mcp-config.json`. See `mcp.instructions.md` for the full guide.
+
+- **Prefer a named Python tool** when one exists (it handles paths, validation, sync).
+- **Fall back to `mcp_call_tool`** for capabilities only exposed by an MCP server.
+- Mutating MCP calls are dry-run unless `MCP_EXECUTE=1` and require approval.
+
 ## GitHub
 
 ### Branching

--- a/.github/instructions/mcp.instructions.md
+++ b/.github/instructions/mcp.instructions.md
@@ -1,0 +1,67 @@
+---
+applyTo: ".github/agents/**"
+description: How agents reach MCP servers (Atlassian, GitHub, filesystem) via CLI tools that execute command prompts. Read this when an agent needs to call an MCP server.
+---
+
+# MCP CLI Integration Guide
+
+Agents reach **MCP (Model Context Protocol) servers** — Atlassian (Jira /
+Confluence), GitHub, the file system, and any other configured server — by
+executing *command prompts* through a command-line MCP client. This is the
+uniform, config-driven path that complements the first-party Python integrations
+(`jira_*`, `confluence_*`): use a named Python tool when one exists; reach for
+the MCP CLI tools for anything a server exposes that isn't wrapped yet.
+
+## Configuration
+
+MCP servers are declared once in **`.github/copilot/mcp-config.json`**
+(the `mcpServers` shape shared by GitHub Copilot CLI and VS Code). Override the
+location with `$MCP_CONFIG_PATH`. The client CLI is `$MCP_CLIENT` (default
+`mcp call`) — set it to whichever MCP client the environment provides
+(`copilot mcp`, `mcp`, …).
+
+```jsonc
+// .github/copilot/mcp-config.json
+{ "mcpServers": {
+    "atlassian":  { "command": "npx", "args": ["-y", "mcp-remote", "https://mcp.atlassian.com/v1/sse"] },
+    "github":     { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"] },
+    "filesystem": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "generated"] }
+} }
+```
+
+## The MCP CLI tools
+
+Registered in `src/tools/integrations/mcp_tools.py` (category `mcp`):
+
+| Tool | Purpose | Approval |
+|------|---------|----------|
+| `mcp_list_servers` | List configured MCP servers | read-only |
+| `mcp_list_tools` | Discover a server's tools (`tools/list`) | read-only |
+| `mcp_call_tool` | Execute a command prompt: call a server tool (`tools/call`) with JSON `arguments` | requires approval |
+| `mcp_run_command` | Run a raw MCP method (`resources/read`, …) — escape hatch | requires approval |
+
+### Usage pattern
+
+1. `mcp_list_servers` — confirm which servers are wired up. If none, **silently
+   skip** MCP steps (never block a phase on integration availability).
+2. `mcp_list_tools(server="atlassian")` — discover the exact tool names before calling.
+3. `mcp_call_tool(server="atlassian", tool="jira_create_issue", arguments={...})`
+   — execute the command prompt for the feature you need.
+
+### Safety
+
+- `mcp_call_tool` / `mcp_run_command` are **dry-run by default**: they resolve
+  and return the exact command without running it. They execute only when
+  `MCP_EXECUTE=1` (or `execute=true` is passed) **and** a client CLI is
+  configured. Inspect the `rendered_command` on a dry run before executing.
+- Both mutating tools are marked `requires_approval` — honour Hybrid/Manual
+  agent modes and pause for approval before executing.
+- Never pass secrets, tokens, or PII as arguments; rely on the server's `env`
+  block (which reads from the environment) for credentials.
+
+## When to prefer what
+
+- **Named Python tool exists** (`jira_create_issue`, `confluence_create_dsdm_doc`,
+  …) → use it; it already handles output paths, validation, and sync.
+- **No wrapper, but an MCP server exposes it** → use `mcp_call_tool`.
+- **Neither** → do it locally (file tools) and note the gap in the hand-off.

--- a/.github/prompts/mcp-sync.prompt.md
+++ b/.github/prompts/mcp-sync.prompt.md
@@ -1,0 +1,35 @@
+---
+mode: agent
+description: Sync DSDM artefacts to external systems (Jira, Confluence, GitHub) by executing command prompts against configured MCP servers via the CLI tools.
+---
+
+# Task: Sync via MCP servers
+
+Push the current phase's artefacts to the relevant external system through the
+**MCP CLI tools**, executing command prompts against configured MCP servers. See
+`.github/instructions/mcp.instructions.md` for the full contract.
+
+## Inputs
+- **Project slug** (the `generated/<slug>/` folder)
+- **Target system**: `atlassian` (Jira/Confluence), `github`, or another configured server
+- **Feature**: what to sync (e.g. publish the business study, seed the backlog, open a release issue)
+
+## Steps
+1. Run `mcp_list_servers` — confirm the target server is configured. If it is not,
+   report "MCP server '<name>' not configured — skipping" and stop (never block).
+2. Run `mcp_list_tools(server="<target>")` to discover the exact tool names.
+3. Build the arguments from the on-disk artefacts under `generated/<slug>/`.
+4. Execute the command prompt with `mcp_call_tool(server="<target>", tool="<tool>", arguments={...})`.
+   - It is a **dry run** by default: inspect the returned `rendered_command`.
+   - To actually run it, set `MCP_EXECUTE=1` (and ensure `$MCP_CLIENT` is set) or
+     pass `execute=true`, then approve when prompted.
+5. For raw protocol methods not exposed as a tool, use `mcp_run_command`.
+
+## Output
+- The `rendered_command` for each MCP call (audit trail)
+- The server response (when executed) or a note that it ran as a dry run
+- A one-line summary of what was synced and where
+
+## Safety
+- Never pass secrets/tokens/PII as arguments — rely on each server's `env` block.
+- `mcp_call_tool` / `mcp_run_command` require approval; honour Hybrid/Manual modes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@ This file is the project-level instruction file read by **GitHub Copilot CLI**, 
 | `docs/` | Source-of-truth requirements, workflow diagram, technical reqs |
 | `generated/` | **All agent output goes here** — one folder per project |
 | `.github/agents/` | Copilot CLI custom agents (one `.agent.md` per role) |
-| `.github/instructions/` | Scoped instruction files (tools, integrations, conventions) |
-| `.github/prompts/` | Reusable task prompts (workflows, single-phase runs, deploys) |
+| `.github/instructions/` | Scoped instruction files (tools, integrations, MCP, conventions) |
+| `.github/prompts/` | Reusable task prompts (workflows, single-phase runs, deploys, MCP sync) |
+| `.github/copilot/mcp-config.json` | MCP server catalogue for the Copilot CLI / MCP CLI tools |
 
 ## DSDM phase agents
 
@@ -55,6 +56,7 @@ Run with `copilot --prompt-file .github/prompts/<file>.prompt.md` (or via the in
 | Implementation / deploy | `.github/prompts/run-implementation.prompt.md` |
 | Code review | `.github/prompts/code-review.prompt.md` |
 | Security review | `.github/prompts/security-review.prompt.md` |
+| MCP sync (Jira/Confluence/GitHub) | `.github/prompts/mcp-sync.prompt.md` |
 
 ## Conventions every agent must follow
 
@@ -63,7 +65,7 @@ Run with `copilot --prompt-file .github/prompts/<file>.prompt.md` (or via the in
 3. **No shortcuts on quality** — DSDM Principle #5: *Never compromise quality*. Tests must run, lint must pass, security scans must be clean before marking a phase complete.
 4. **MoSCoW everywhere** — requirements, user stories, and roadmap items must be tagged Must / Should / Could / Won't.
 5. **Hand-off contract** — when a phase finishes, summarise the artefacts produced and the inputs the next phase needs.
-6. **Jira / Confluence sync** — when those MCP servers are available, mirror status changes (`jira_transition_issue`, `sync_work_item_status`, `confluence_update_page`).
+6. **Jira / Confluence sync** — when those integrations are available, mirror status changes (`jira_transition_issue`, `sync_work_item_status`, `confluence_update_page`). If a system is reachable only as an **MCP server**, use the MCP CLI tools (`mcp_list_servers` → `mcp_list_tools` → `mcp_call_tool`) to execute the same command prompts — see `.github/instructions/mcp.instructions.md`.
 7. **Stop when done** — once the deliverables exist on disk, write a final summary and stop. Do not loop on tool calls.
 
 ## Environment

--- a/src/orchestrator/delivery_room_orchestrator.py
+++ b/src/orchestrator/delivery_room_orchestrator.py
@@ -26,6 +26,7 @@ class DSDMOrchestrator(BaseDSDMOrchestrator):
         include_devops: bool = True,
         include_confluence: bool = True,
         include_jira: bool = True,
+        include_mcp: bool = True,
         show_progress: bool = True,
         include_delivery_room: bool = True,
     ):
@@ -34,6 +35,7 @@ class DSDMOrchestrator(BaseDSDMOrchestrator):
             include_devops=include_devops,
             include_confluence=include_confluence,
             include_jira=include_jira,
+            include_mcp=include_mcp,
             show_progress=show_progress,
         )
         self.include_delivery_room = include_delivery_room

--- a/src/orchestrator/dsdm_orchestrator.py
+++ b/src/orchestrator/dsdm_orchestrator.py
@@ -141,6 +141,7 @@ class DSDMOrchestrator:
         include_devops: bool = True,
         include_confluence: bool = True,
         include_jira: bool = True,
+        include_mcp: bool = True,
         show_progress: bool = True,
     ):
         self.config = config or self._default_config()
@@ -149,6 +150,7 @@ class DSDMOrchestrator:
             include_confluence=include_confluence,
             include_jira=include_jira,
             include_devops=include_devops,
+            include_mcp=include_mcp,
         )
         self.console = Console()
         self.formatter = get_formatter(self.console)

--- a/src/tools/dsdm_tools.py
+++ b/src/tools/dsdm_tools.py
@@ -19,6 +19,7 @@ def create_dsdm_tool_registry(
     include_devops: bool = False,
     include_file_tools: bool = True,
     include_git_pin: bool = True,
+    include_mcp: bool = True,
 ) -> ToolRegistry:
     """Create a tool registry with all DSDM tools."""
     registry = ToolRegistry()
@@ -1310,6 +1311,10 @@ def create_dsdm_tool_registry(
     if include_devops:
         from .integrations.devops_tools import register_devops_tools
         register_devops_tools(registry)
+
+    if include_mcp:
+        from .integrations.mcp_tools import register_mcp_tools
+        register_mcp_tools(registry)
 
     if include_file_tools:
         from .file_tools import register_file_tools

--- a/src/tools/integrations/__init__.py
+++ b/src/tools/integrations/__init__.py
@@ -1,5 +1,11 @@
 from .confluence_tools import register_confluence_tools
 from .jira_tools import register_jira_tools
 from .devops_tools import register_devops_tools
+from .mcp_tools import register_mcp_tools
 
-__all__ = ["register_confluence_tools", "register_jira_tools", "register_devops_tools"]
+__all__ = [
+    "register_confluence_tools",
+    "register_jira_tools",
+    "register_devops_tools",
+    "register_mcp_tools",
+]

--- a/src/tools/integrations/mcp_tools.py
+++ b/src/tools/integrations/mcp_tools.py
@@ -1,0 +1,328 @@
+"""MCP (Model Context Protocol) CLI tools for DSDM agents.
+
+These tools let an agent reach **MCP servers** — Atlassian (Jira/Confluence),
+GitHub, the file system, and any other configured server — by executing
+*command prompts* through a command-line MCP client. This complements the
+first-party Python integrations (`jira_tools`, `confluence_tools`): where those
+call vendor REST APIs directly, the MCP tools give agents a uniform,
+config-driven way to invoke whatever an MCP server exposes.
+
+Design notes
+------------
+* **Config-driven** — servers are declared once in an ``mcp-config.json``
+  (``mcpServers`` shape, matching GitHub Copilot CLI / VS Code). The default
+  location is ``.github/copilot/mcp-config.json`` or ``$MCP_CONFIG_PATH``.
+* **Client-agnostic** — the client CLI is ``$MCP_CLIENT`` (whitespace-split),
+  defaulting to ``mcp call``. Swap it for ``copilot mcp`` or any client that
+  speaks the same ``--server/--method/--tool/--arguments`` flags.
+* **Safe by default** — invoking a tool (``mcp_call_tool`` / ``mcp_run_command``)
+  requires approval and only executes when ``$MCP_EXECUTE`` is truthy; otherwise
+  it returns the fully-resolved command as a dry run. Discovery tools
+  (``mcp_list_servers`` / ``mcp_list_tools``) are read-only.
+"""
+
+import json
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..tool_registry import Tool, ToolRegistry
+
+# MCP JSON-RPC methods understood by the client. A bare tool name is treated as
+# ``tools/call <name>``.
+_PROTOCOL_METHODS = {
+    "tools/list",
+    "tools/call",
+    "resources/list",
+    "resources/read",
+    "prompts/list",
+}
+
+_DEFAULT_CLIENT = ["mcp", "call"]
+_DEFAULT_CONFIG_PATHS = (
+    ".github/copilot/mcp-config.json",
+    ".vscode/mcp.json",
+)
+
+
+class MCPCliClient:
+    """Bridge to MCP servers via a command-line MCP client."""
+
+    def __init__(
+        self,
+        config_path: Optional[str] = None,
+        client: Optional[List[str]] = None,
+    ) -> None:
+        self._config_path = config_path or os.environ.get("MCP_CONFIG_PATH")
+        self._servers: Optional[Dict[str, Dict[str, Any]]] = None
+        if client is not None:
+            self._client = list(client)
+        elif os.environ.get("MCP_CLIENT"):
+            self._client = shlex.split(os.environ["MCP_CLIENT"])
+        else:
+            self._client = list(_DEFAULT_CLIENT)
+
+    # -- configuration -----------------------------------------------------
+    def _resolve_config_path(self) -> Optional[Path]:
+        if self._config_path:
+            return Path(self._config_path)
+        for candidate in _DEFAULT_CONFIG_PATHS:
+            path = Path(candidate)
+            if path.exists():
+                return path
+        return None
+
+    @property
+    def servers(self) -> Dict[str, Dict[str, Any]]:
+        """Configured MCP servers, loaded lazily from the config file."""
+        if self._servers is None:
+            path = self._resolve_config_path()
+            if path and path.exists():
+                with open(path, "r", encoding="utf-8") as handle:
+                    data = json.load(handle)
+                self._servers = dict(data.get("mcpServers", data))
+            else:
+                self._servers = {}
+        return self._servers
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.servers)
+
+    def _server_env(self, server: str) -> Dict[str, str]:
+        env = self.servers.get(server, {}).get("env", {}) or {}
+        return {str(k): str(v) for k, v in env.items()}
+
+    # -- command construction ---------------------------------------------
+    def build_argv(
+        self,
+        server: str,
+        method_or_tool: str,
+        arguments: Optional[Dict[str, Any]] = None,
+    ) -> List[str]:
+        """Build the client argv for a server invocation."""
+        if server not in self.servers:
+            raise ValueError(
+                f"Unknown MCP server '{server}'. Configured: {sorted(self.servers)}"
+            )
+
+        argv = list(self._client) + ["--server", server]
+        if method_or_tool in _PROTOCOL_METHODS:
+            argv += ["--method", method_or_tool]
+        else:
+            argv += ["--method", "tools/call", "--tool", method_or_tool]
+        if arguments:
+            argv += ["--arguments", json.dumps(arguments, sort_keys=True)]
+        return argv
+
+    # -- execution ---------------------------------------------------------
+    def invoke(
+        self,
+        server: str,
+        method_or_tool: str,
+        arguments: Optional[Dict[str, Any]] = None,
+        execute: Optional[bool] = None,
+        timeout: int = 120,
+    ) -> Dict[str, Any]:
+        """Resolve and (optionally) run a command prompt against a server."""
+        argv = self.build_argv(server, method_or_tool, arguments)
+        rendered = " ".join(shlex.quote(token) for token in argv)
+        payload: Dict[str, Any] = {
+            "success": True,
+            "server": server,
+            "command": method_or_tool,
+            "arguments": arguments or {},
+            "argv": argv,
+            "rendered_command": rendered,
+        }
+
+        if execute is None:
+            execute = _truthy(os.environ.get("MCP_EXECUTE"))
+        if not execute:
+            payload["executed"] = False
+            payload["dry_run"] = True
+            payload["note"] = (
+                "Dry run — set MCP_EXECUTE=1 (or pass execute=true) with a client "
+                "CLI configured ($MCP_CLIENT) to run this command."
+            )
+            return payload
+
+        try:
+            completed = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env={**os.environ, **self._server_env(server)},
+            )
+            payload.update(
+                executed=True,
+                dry_run=False,
+                success=completed.returncode == 0,
+                returncode=completed.returncode,
+                stdout=completed.stdout,
+                stderr=completed.stderr,
+            )
+        except subprocess.TimeoutExpired:
+            payload.update(success=False, executed=True, error=f"MCP command timed out after {timeout}s")
+        except FileNotFoundError as exc:
+            payload.update(
+                success=False,
+                executed=False,
+                error=f"MCP client not found ({exc}). Set $MCP_CLIENT to an installed client.",
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced in the payload
+            payload.update(success=False, executed=True, error=str(exc))
+        return payload
+
+
+def _truthy(value: Optional[str]) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+# Module-level client reused across tool handlers.
+_client = MCPCliClient()
+
+
+# ==================== TOOL HANDLERS ====================
+
+def _handle_list_servers() -> str:
+    servers = _client.servers
+    return json.dumps({
+        "success": True,
+        "configured": bool(servers),
+        "servers": {
+            name: {"command": spec.get("command"), "args": spec.get("args", [])}
+            for name, spec in servers.items()
+        },
+        "count": len(servers),
+    })
+
+
+def _handle_list_tools(server: str) -> str:
+    return json.dumps(_client.invoke(server, "tools/list"))
+
+
+def _handle_call_tool(
+    server: str,
+    tool: str,
+    arguments: Optional[Dict[str, Any]] = None,
+    execute: Optional[bool] = None,
+) -> str:
+    return json.dumps(_client.invoke(server, tool, arguments=arguments, execute=execute))
+
+
+def _handle_run_command(
+    server: str,
+    method: str,
+    arguments: Optional[Dict[str, Any]] = None,
+    execute: Optional[bool] = None,
+) -> str:
+    return json.dumps(_client.invoke(server, method, arguments=arguments, execute=execute))
+
+
+# ==================== REGISTRATION ====================
+
+def register_mcp_tools(registry: ToolRegistry) -> None:
+    """Register MCP CLI tools with the registry."""
+
+    registry.register(Tool(
+        name="mcp_list_servers",
+        description=(
+            "List the MCP servers configured for this repo (from "
+            ".github/copilot/mcp-config.json or $MCP_CONFIG_PATH). Read-only."
+        ),
+        input_schema={"type": "object", "properties": {}},
+        handler=_handle_list_servers,
+        category="mcp",
+    ))
+
+    registry.register(Tool(
+        name="mcp_list_tools",
+        description=(
+            "Discover the tools an MCP server exposes by running its 'tools/list' "
+            "method through the CLI client. Read-only."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "server": {
+                    "type": "string",
+                    "description": "Configured MCP server name (e.g. 'atlassian', 'github').",
+                },
+            },
+            "required": ["server"],
+        },
+        handler=_handle_list_tools,
+        category="mcp",
+    ))
+
+    registry.register(Tool(
+        name="mcp_call_tool",
+        description=(
+            "Execute a command prompt against an MCP server by calling one of its "
+            "tools (tools/call). Pass the tool name and a JSON 'arguments' object. "
+            "Dry-run unless MCP_EXECUTE is set or execute=true."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "server": {
+                    "type": "string",
+                    "description": "Configured MCP server name (e.g. 'atlassian', 'github').",
+                },
+                "tool": {
+                    "type": "string",
+                    "description": "The MCP tool to invoke (e.g. 'jira_create_issue').",
+                },
+                "arguments": {
+                    "type": "object",
+                    "description": "JSON arguments passed to the MCP tool.",
+                },
+                "execute": {
+                    "type": "boolean",
+                    "description": "Actually run the command (default: dry run unless MCP_EXECUTE).",
+                },
+            },
+            "required": ["server", "tool"],
+        },
+        handler=_handle_call_tool,
+        requires_approval=True,
+        category="mcp",
+    ))
+
+    registry.register(Tool(
+        name="mcp_run_command",
+        description=(
+            "Run a raw MCP protocol method (e.g. 'tools/call', 'resources/read') "
+            "against a server — escape hatch for capabilities not covered by a "
+            "named tool. Dry-run unless MCP_EXECUTE is set or execute=true."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "server": {
+                    "type": "string",
+                    "description": "Configured MCP server name.",
+                },
+                "method": {
+                    "type": "string",
+                    "description": "MCP method or tool name to invoke.",
+                },
+                "arguments": {
+                    "type": "object",
+                    "description": "JSON arguments for the method/tool.",
+                },
+                "execute": {
+                    "type": "boolean",
+                    "description": "Actually run the command (default: dry run unless MCP_EXECUTE).",
+                },
+            },
+            "required": ["server", "method"],
+        },
+        handler=_handle_run_command,
+        requires_approval=True,
+        category="mcp",
+    ))

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,102 @@
+"""Tests for the MCP CLI tools."""
+
+import json
+
+from src.tools.integrations.mcp_tools import MCPCliClient, register_mcp_tools
+from src.tools.tool_registry import ToolRegistry
+
+_SERVERS = {
+    "atlassian": {"command": "npx", "args": ["-y", "mcp-remote", "https://example/sse"]},
+    "github": {"command": "npx", "args": ["-y", "server-github"], "env": {"TOKEN": "x"}},
+}
+
+
+def _client(tmp_path):
+    cfg = tmp_path / "mcp-config.json"
+    cfg.write_text(json.dumps({"mcpServers": _SERVERS}))
+    return MCPCliClient(config_path=str(cfg), client=["mcp", "call"])
+
+
+def _registry(tmp_path, monkeypatch):
+    monkeypatch.delenv("MCP_EXECUTE", raising=False)
+    cfg = tmp_path / "mcp-config.json"
+    cfg.write_text(json.dumps({"mcpServers": _SERVERS}))
+    monkeypatch.setenv("MCP_CONFIG_PATH", str(cfg))
+    # Reset the module-level client so it picks up the test config.
+    import src.tools.integrations.mcp_tools as mod
+
+    mod._client = MCPCliClient(config_path=str(cfg), client=["mcp", "call"])
+    registry = ToolRegistry()
+    register_mcp_tools(registry)
+    return registry
+
+
+# -- client ----------------------------------------------------------------
+def test_lists_servers_from_config(tmp_path):
+    assert sorted(_client(tmp_path).servers) == ["atlassian", "github"]
+
+
+def test_protocol_method_argv(tmp_path):
+    argv = _client(tmp_path).build_argv("atlassian", "tools/list")
+    assert argv == ["mcp", "call", "--server", "atlassian", "--method", "tools/list"]
+
+
+def test_bare_tool_name_becomes_tools_call(tmp_path):
+    argv = _client(tmp_path).build_argv(
+        "atlassian", "jira_create_issue", {"summary": "hi"}
+    )
+    assert "--method" in argv and "tools/call" in argv
+    assert "--tool" in argv and "jira_create_issue" in argv
+    assert json.loads(argv[-1]) == {"summary": "hi"}
+
+
+def test_unknown_server_raises(tmp_path):
+    try:
+        _client(tmp_path).build_argv("jira", "tools/list")
+    except ValueError as exc:
+        assert "Unknown MCP server" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
+def test_invoke_is_dry_run_by_default(tmp_path):
+    out = _client(tmp_path).invoke("atlassian", "tools/list")
+    assert out["dry_run"] is True and out["executed"] is False
+    assert out["rendered_command"].startswith("mcp call --server atlassian")
+
+
+# -- registered tools ------------------------------------------------------
+def test_registered_tools(tmp_path, monkeypatch):
+    registry = _registry(tmp_path, monkeypatch)
+    assert {t.name for t in registry.get_by_category("mcp")} == {
+        "mcp_list_servers",
+        "mcp_list_tools",
+        "mcp_call_tool",
+        "mcp_run_command",
+    }
+
+
+def test_list_servers_tool(tmp_path, monkeypatch):
+    registry = _registry(tmp_path, monkeypatch)
+    result = json.loads(registry.execute("mcp_list_servers"))
+    assert result["success"] and result["count"] == 2
+
+
+def test_call_tool_dry_run(tmp_path, monkeypatch):
+    registry = _registry(tmp_path, monkeypatch)
+    result = json.loads(
+        registry.execute(
+            "mcp_call_tool",
+            server="atlassian",
+            tool="jira_create_issue",
+            arguments={"project_key": "DSDM", "summary": "x"},
+        )
+    )
+    assert result["dry_run"] is True
+    assert "jira_create_issue" in result["rendered_command"]
+
+
+def test_call_tool_requires_approval(tmp_path, monkeypatch):
+    registry = _registry(tmp_path, monkeypatch)
+    assert registry.get("mcp_call_tool").requires_approval is True
+    assert registry.get("mcp_list_servers").requires_approval is False


### PR DESCRIPTION
Add MCP CLI tools so DSDM agents can execute command prompts against any
configured MCP server (Atlassian, GitHub, filesystem, …) — a uniform,
config-driven path alongside the first-party Jira/Confluence Python tools.

Code:
- src/tools/integrations/mcp_tools.py: MCPCliClient + four registered tools
  (mcp_list_servers, mcp_list_tools, mcp_call_tool, mcp_run_command).
  Config-driven (.github/copilot/mcp-config.json / $MCP_CONFIG_PATH),
  client-agnostic ($MCP_CLIENT), dry-run unless $MCP_EXECUTE; mutating
  calls require approval.
- wire include_mcp through create_dsdm_tool_registry and both orchestrators.
- .github/copilot/mcp-config.json server catalogue; MCP_* vars in .env.example.
- tests/test_mcp_tools.py.

Skills & tasks:
- new .github/instructions/mcp.instructions.md guide.
- new .github/prompts/mcp-sync.prompt.md task.
- extend feasibility, business-study, product-manager, implementation,
  devops, and dev-lead agents with concrete MCP CLI usage.
- update AGENTS.md, integrations/dsdm-tools instructions, and agents README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FtrC1fcjdEWGYUanc8LUXx