### PR TITLE
Close Delivery Room PRD gaps: structured kickoff artifact + README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,33 @@ python main.py --pi-doctor --agent-runtime pi --llm-provider vllm
 
 `PRD_TRD` always runs on the legacy path (its two-agent Product Manager/Dev Lead sub-workflow hasn't been ported yet). See `docs/category-defining-features/11-pi-agent-runtime/` for the full PRD/TRD and migration roadmap.
 
+#### Autonomous Delivery Room
+
+Instead of running isolated phase agents, a Delivery Room coordinates the full AI product team (Product Owner, Business Analyst, Architect, Frontend/Backend Developer, QA, Security, Release Manager, and more) against one project workspace — with shared role ownership, a decision log, a blocker log, cross-agent handoffs, and a health score.
+
+```bash
+# Create a room and see the kickoff artifact (goals, assumptions, stakeholders, risks, sequence)
+python main.py --room-create --input "Build a task management platform" --room-project "Task Platform" --room-template mvp
+
+# Create AND run the room through the real DSDM orchestrator, phase by phase
+python main.py --room-run --input "Build a task management platform" --room-project "Task Platform"
+
+# Check status (agents, blockers, decisions, health, goals/risks) at any time
+python main.py --room-status --room-project task-platform
+
+# Get a focused view (e.g. only blockers and decisions owned by one agent)
+python main.py --room-dashboard --room-project task-platform --dashboard-sections blockers,decisions --dashboard-agent BusinessStudyAgent
+
+# Export the full dashboard to generated/<project>/docs/DELIVERY_ROOM.md
+python main.py --room-export --room-project task-platform
+```
+
+- **Templates** (`--room-template`): `mvp` (default), `platform`, `migration`, `enterprise`, `compliance` — each adjusts role assignments, kickoff goals/risks, and recommended next actions for that kind of project.
+- **State**: persisted as JSON at `generated/<project>/room_state.json`; the Markdown dashboard lives at `generated/<project>/docs/DELIVERY_ROOM.md`.
+- **Programmatic access**: `src.rooms` exposes `create_delivery_room`, `run_delivery_room`, `get_delivery_room_status`, `add_room_decision`, `add_room_blocker`, `add_room_handoff`, and more; the same operations are also registered as agent tools (`room_create`, `room_get_status`, `room_get_health`, ...) so any agent can update room state mid-workflow.
+
+See `docs/category-defining-features/01-autonomous-delivery-room/` for the full PRD/TRD.
+
 ### Output & Project Management
 
 #### Auto-Generated Artifacts
@@ -531,6 +558,11 @@ python main.py --list-tools
 | `--llm-provider <provider>` | `anthropic`, `openai`, `gemini`, `ollama`, or `vllm` | `python main.py --llm-provider vllm --agent-runtime pi --input "..."` |
 | `--pi-doctor` | Diagnose the pi.dev runtime setup and exit | `python main.py --pi-doctor` |
 | `--generate-agents` | Check role definitions for drift and exit | `python main.py --generate-agents` |
+| `--room-create` | Create an Autonomous Delivery Room (see below) | `python main.py --room-create --input "Build an MVP" --room-project "My Project"` |
+| `--room-run` | Create and run a Delivery Room workflow through the real orchestrator | `python main.py --room-run --input "Build an MVP" --room-project "My Project"` |
+| `--room-status` | Show a Delivery Room's status | `python main.py --room-status --room-project my-project` |
+| `--room-dashboard` | Show a filtered Delivery Room dashboard | `python main.py --room-dashboard --room-project my-project --dashboard-sections summary,blockers` |
+| `--room-export` | Export the full Delivery Room dashboard to Markdown | `python main.py --room-export --room-project my-project` |
 
 #### Valid Phase Names
 

--- a/main.py
+++ b/main.py
@@ -272,6 +272,14 @@ def _print_room_status(console: Console, project_name: str) -> None:
     console.print(f"Template: {status['template']}")
     console.print(f"Status: {status['status']}")
     console.print(f"Active phase: {status['active_phase']}")
+    if status.get("goals"):
+        console.print("\n[bold]Goals[/bold]")
+        for goal in status["goals"]:
+            console.print(f"  • {goal}")
+    if status.get("risks"):
+        console.print("\n[bold]Risks[/bold]")
+        for risk in status["risks"]:
+            console.print(f"  • {risk}")
     if health:
         console.print(f"Health: {health.get('overall')}/100 ({health.get('status')}, confidence {health.get('confidence')}/100)")
     console.print(f"Open blockers: {status['open_blocker_count']}")

--- a/src/rooms/__init__.py
+++ b/src/rooms/__init__.py
@@ -29,6 +29,7 @@ from .room_state import (
     RoomBlocker,
     RoomDecision,
     RoomHandoff,
+    RoomKickoff,
 )
 
 __all__ = [
@@ -40,6 +41,7 @@ __all__ = [
     "RoomEvent",
     "RoomEventType",
     "RoomHandoff",
+    "RoomKickoff",
     "add_room_blocker",
     "add_room_decision",
     "add_room_handoff",

--- a/src/rooms/delivery_room.py
+++ b/src/rooms/delivery_room.py
@@ -15,7 +15,12 @@ from .room_state import (
     RoomDecision,
     RoomHandoff,
 )
-from .room_templates import get_template_agents, get_template_next_actions, normalize_template
+from .room_templates import (
+    get_template_agents,
+    get_template_kickoff,
+    get_template_next_actions,
+    normalize_template,
+)
 
 
 GENERATED_ROOT = Path("generated")
@@ -77,12 +82,16 @@ def create_delivery_room(
     if path.exists() and not overwrite:
         return load_delivery_room(resolved_project_name)
 
+    kickoff = get_template_kickoff(normalized_template)
+    kickoff.goals.insert(0, f"Deliver on the stated mission: {mission.strip()}")
+
     room = DeliveryRoomState(
         project_name=resolved_project_name,
         mission=mission.strip(),
         template=normalized_template,
         status="created",
         active_phase="kickoff",
+        kickoff=kickoff,
         agents=get_template_agents(normalized_template),
         next_actions=get_template_next_actions(normalized_template),
     )
@@ -251,6 +260,8 @@ def get_delivery_room_status(project_name: str) -> Dict[str, Any]:
         "template": room.template,
         "status": room.status,
         "active_phase": room.active_phase,
+        "goals": room.kickoff.goals,
+        "risks": room.kickoff.risks,
         "agent_count": len(room.agents),
         "completed_agent_count": len(completed_agents),
         "decision_count": len(room.decisions),
@@ -274,6 +285,22 @@ def format_delivery_room_markdown(room: DeliveryRoomState) -> str:
         f"**Active phase:** {room.active_phase or 'None'}",
         f"**Updated:** {room.updated_at}",
         "",
+        "## Kickoff",
+        "",
+        "### Goals",
+        "",
+    ]
+    lines.extend([f"- {item}" for item in room.kickoff.goals] or ["- No goals recorded yet."])
+    lines.extend(["", "### Assumptions", ""])
+    lines.extend([f"- {item}" for item in room.kickoff.assumptions] or ["- No assumptions recorded yet."])
+    lines.extend(["", "### Stakeholders", ""])
+    lines.extend([f"- {item}" for item in room.kickoff.stakeholders] or ["- No stakeholders recorded yet."])
+    lines.extend(["", "### Risks", ""])
+    lines.extend([f"- {item}" for item in room.kickoff.risks] or ["- No risks recorded yet."])
+    lines.extend(["", "### Sequence", ""])
+    lines.extend([f"{i}. {item}" for i, item in enumerate(room.kickoff.sequence, start=1)] or ["1. No sequence recorded yet."])
+    lines.extend([
+        "",
         "## Health",
         "",
         f"**Overall:** {health.overall}/100 ({health.status})",
@@ -289,7 +316,7 @@ def format_delivery_room_markdown(room: DeliveryRoomState) -> str:
         "",
         "### Weak Points",
         "",
-    ]
+    ])
     lines.extend([f"- {item}" for item in health.weak_points] or ["- No weak points detected from current room data."])
     lines.extend(["", "### Recommended Actions", ""])
     lines.extend([f"- {item}" for item in health.recommended_actions] or ["- Continue with the next planned DSDM phase."])

--- a/src/rooms/room_state.py
+++ b/src/rooms/room_state.py
@@ -77,6 +77,17 @@ class RoomArtifact:
 
 
 @dataclass
+class RoomKickoff:
+    """Kickoff artifact: goals, assumptions, stakeholders, risks, and sequence."""
+
+    goals: List[str] = field(default_factory=list)
+    assumptions: List[str] = field(default_factory=list)
+    stakeholders: List[str] = field(default_factory=list)
+    risks: List[str] = field(default_factory=list)
+    sequence: List[str] = field(default_factory=list)
+
+
+@dataclass
 class DeliveryRoomState:
     """Persisted state for an Autonomous Delivery Room."""
 
@@ -85,6 +96,7 @@ class DeliveryRoomState:
     template: str
     status: str = "created"
     active_phase: Optional[str] = None
+    kickoff: RoomKickoff = field(default_factory=RoomKickoff)
     agents: List[RoomAgentAssignment] = field(default_factory=list)
     decisions: List[RoomDecision] = field(default_factory=list)
     blockers: List[RoomBlocker] = field(default_factory=list)
@@ -112,6 +124,7 @@ class DeliveryRoomState:
             template=data.get("template", "mvp"),
             status=data.get("status", "created"),
             active_phase=data.get("active_phase"),
+            kickoff=RoomKickoff(**data.get("kickoff", {})),
             agents=[RoomAgentAssignment(**item) for item in data.get("agents", [])],
             decisions=[RoomDecision(**item) for item in data.get("decisions", [])],
             blockers=[RoomBlocker(**item) for item in data.get("blockers", [])],

--- a/src/rooms/room_templates.py
+++ b/src/rooms/room_templates.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-from .room_state import RoomAgentAssignment
+from .room_state import RoomAgentAssignment, RoomKickoff
 
 
 TEMPLATE_NAMES = {"mvp", "platform", "migration", "enterprise", "compliance"}
@@ -128,6 +128,94 @@ TEMPLATE_NEXT_ACTIONS: Dict[str, List[str]] = {
 }
 
 
+TEMPLATE_KICKOFF: Dict[str, RoomKickoff] = {
+    "mvp": RoomKickoff(
+        goals=[
+            "Ship a working MVP that proves the core mission end-to-end",
+            "Validate the highest-value user journey before broad investment",
+        ],
+        assumptions=[
+            "Requirements will be refined further once real user feedback exists",
+            "Scope will be trimmed hard to protect Must-have requirements",
+        ],
+        stakeholders=["Product Owner", "End users", "Engineering team"],
+        risks=[
+            "Scope creep beyond Must-have requirements",
+            "Insufficient user validation before build",
+        ],
+        sequence=["Feasibility", "Business Study", "PRD/TRD", "Design & Build", "Implementation"],
+    ),
+    "platform": RoomKickoff(
+        goals=[
+            "Establish a platform foundation that supports multiple participant types",
+            "Identify durable network-effect and ecosystem opportunities",
+        ],
+        assumptions=[
+            "Initial release targets one core interaction loop before broader ecosystem investment",
+            "Partner and API surfaces will evolve after the core loop is validated",
+        ],
+        stakeholders=["Product Owner", "Platform Strategist", "Customers", "Suppliers/partners"],
+        risks=[
+            "Two-sided marketplace cold-start risk",
+            "Trust and safety gaps at launch",
+            "Premature platform investment before the core loop is proven",
+        ],
+        sequence=["Feasibility", "Business Study", "PRD/TRD", "Platform Strategy", "Design & Build", "Implementation"],
+    ),
+    "migration": RoomKickoff(
+        goals=[
+            "Migrate the existing system without disrupting current operations",
+            "Preserve data integrity and continuity throughout cutover",
+        ],
+        assumptions=[
+            "Legacy system constraints are documented before design begins",
+            "A rollback plan exists before cutover",
+        ],
+        stakeholders=["Product Owner", "Solution Architect", "Operations team", "Existing system owners"],
+        risks=[
+            "Data loss or corruption during cutover",
+            "Extended downtime during migration",
+            "Undocumented legacy dependencies",
+        ],
+        sequence=["Feasibility", "Business Study", "PRD/TRD", "Design & Build", "Phased Cutover", "Implementation"],
+    ),
+    "enterprise": RoomKickoff(
+        goals=[
+            "Deliver a solution that satisfies enterprise governance and integration requirements",
+            "Establish a staged release and support model",
+        ],
+        assumptions=[
+            "Governance and audit gates are identified before Design & Build starts",
+            "Integration constraints are captured during Business Study",
+        ],
+        stakeholders=["Product Owner", "Solution Architect", "Enterprise sponsors", "Support/operations team"],
+        risks=[
+            "Missed governance or approval gates",
+            "Integration constraints discovered late",
+            "Support model not ready at release",
+        ],
+        sequence=["Feasibility", "Business Study", "PRD/TRD", "Design & Build", "Implementation", "Staged Release"],
+    ),
+    "compliance": RoomKickoff(
+        goals=[
+            "Deliver a solution that meets regulatory and data-protection requirements",
+            "Produce audit-ready evidence at every phase",
+        ],
+        assumptions=[
+            "Regulatory requirements are identified before Business Study concludes",
+            "Compliance review gates apply to every phase",
+        ],
+        stakeholders=["Product Owner", "Compliance Reviewer", "Security Tester", "Auditors/regulators"],
+        risks=[
+            "Non-compliance with regulatory requirements",
+            "Insufficient audit evidence at release",
+            "Security vulnerabilities in compliance-sensitive areas",
+        ],
+        sequence=["Feasibility", "Business Study", "PRD/TRD", "Design & Build", "Compliance Review", "Implementation"],
+    ),
+}
+
+
 def normalize_template(template: str | None) -> str:
     """Normalize a template name, defaulting safely to MVP."""
     value = (template or "mvp").strip().lower().replace(" ", "_").replace("-", "_")
@@ -171,3 +259,16 @@ def get_template_next_actions(template: str | None) -> List[str]:
     """Return default next actions for a template."""
     normalized = normalize_template(template)
     return list(TEMPLATE_NEXT_ACTIONS[normalized])
+
+
+def get_template_kickoff(template: str | None) -> RoomKickoff:
+    """Return the kickoff artifact (goals, assumptions, stakeholders, risks, sequence) for a template."""
+    normalized = normalize_template(template)
+    base = TEMPLATE_KICKOFF[normalized]
+    return RoomKickoff(
+        goals=list(base.goals),
+        assumptions=list(base.assumptions),
+        stakeholders=list(base.stakeholders),
+        risks=list(base.risks),
+        sequence=list(base.sequence),
+    )

--- a/tests/test_delivery_room.py
+++ b/tests/test_delivery_room.py
@@ -66,6 +66,32 @@ def test_create_delivery_room_persists_state(tmp_path, monkeypatch):
     assert get_room_export_path("task-platform").exists()
 
 
+def test_create_delivery_room_generates_kickoff_artifact(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    room = create_delivery_room("Build a supplier marketplace", project_name="Supplier Marketplace", template="platform")
+    assert any("Build a supplier marketplace" in goal for goal in room.kickoff.goals)
+    assert room.kickoff.assumptions
+    assert room.kickoff.stakeholders
+    assert room.kickoff.risks
+    assert room.kickoff.sequence
+
+    status = get_delivery_room_status("supplier-marketplace")
+    assert status["goals"] == room.kickoff.goals
+    assert status["risks"] == room.kickoff.risks
+
+    export_path = export_delivery_room("supplier-marketplace")
+    content = export_path.read_text(encoding="utf-8")
+    assert "## Kickoff" in content
+    assert "### Goals" in content
+    assert "### Assumptions" in content
+    assert "### Stakeholders" in content
+    assert "### Risks" in content
+    assert "### Sequence" in content
+
+    reloaded = load_delivery_room("supplier-marketplace")
+    assert reloaded.kickoff.goals == room.kickoff.goals
+
+
 def test_room_status_counts_decisions_blockers_and_handoffs(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     create_delivery_room("Build a marketplace", project_name="Marketplace", template="platform")


### PR DESCRIPTION
ADR-PRD-FR-003 asked for a kickoff artifact with goals, assumptions,
stakeholders, risks, and sequence, but create_delivery_room() only ever
populated a generic next_actions list. Add a RoomKickoff model, seed it
per-template (mvp/platform/migration/enterprise/compliance), surface it
in the room status dict, the CLI status printer, and a new Kickoff
section in the Markdown export.

Also document the previously-unmentioned --room-create/--room-run/
--room-status/--room-dashboard/--room-export CLI flags in README.md,
since they were fully wired but invisible to users.